### PR TITLE
Removed visibility rule only for Create/ Update

### DIFF
--- a/cnameRecordManager/task.json
+++ b/cnameRecordManager/task.json
@@ -66,7 +66,6 @@
           "required": true,
           "helpMarkDown":"",
           "groupName": "dnszonedetail",
-          "visibleRule": "actionType = createUpdate"
         },
         {
           "name": "ttl",


### PR DESCRIPTION
Removed line:  "visibleRule": "actionType = createUpdate"
Reason: When Action type is Remove, alias is removed from the editor. If you try to remove you get this error: ##[error]Input required: alias